### PR TITLE
Add initial ES6 eslint config.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,2 +1,13 @@
-@TODO replace for real rules.
+{
+  "extends": [
+    'eslint-config-airbnb-base',
+  ],
+  "parser": "babel-eslint",
+  "rules": {
+    "max-len": [2, 120, 2, {
+      "ignoreUrls": true,
+      "ignoreComments": false
+    }],
+  }
+}
 


### PR DESCRIPTION
I tested this config file using the following modules and versions:
```
     "babel-eslint": "5.0.0",
     "eslint": "3.5.0",
     "eslint-config-airbnb": "11.1.0",
     "eslint-config-airbnb-base": "7.1.0",
     "eslint-plugin-import": "1.15.0",
```